### PR TITLE
Remove comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "unity": "2018.3",
     "description": "A port of the old edge detection post processing effect for the v2 stack.",
     "dependencies": {
-    	"com.unity.postprocessing": "2.1.6",
+    	"com.unity.postprocessing": "2.1.6"
     }
 }


### PR DESCRIPTION
That extra comma was giving errors when trying to clone the repo via Unity's package manager